### PR TITLE
test: pilot v2 of content-guardian-action (PR #335)

### DIFF
--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         # markupai/content-guardian-action (adds review-comment reconciliation:
         # stale comments are now auto-deleted on re-runs).
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@4289732252ef9146bdf34896f9cb484b1c5bc999
+        uses: markupai/content-guardian-action@d0c776ff4c0948a02bb758fc7fc9a05319575ab9
         with:
           target: Main
         env:

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         # markupai/content-guardian-action (adds review-comment reconciliation:
         # stale comments are now auto-deleted on re-runs).
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@96a0b0fd32ba6529b5e5cef4299d9e8975781589
+        uses: markupai/content-guardian-action@c766459b346d47b7fa70d641ec2d728e67e42e26
         with:
           target: Main
         env:

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: "0 8 * * *"
   workflow_dispatch:
 
 permissions:
@@ -21,12 +21,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Markup AI Analysis
-        uses: markupai/content-guardian-action@v1
+        # v2 pre-release pinned to the commit on PR #335 in markupai/content-guardian-action.
+        # See https://github.com/markupai/content-guardian-action/pull/335
+        uses: markupai/content-guardian-action@6e6ccc87bb5aa67657fa3663fe5d9637fe0ffbec
         with:
-          # valid tones: academic, confident, conversational, empathetic, engaging, friendly, professional, style_guide, technical
-          tone: professional
-          dialect: american_english
-          style-guide: microsoft
+          target: Main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MARKUP_AI_API_KEY: ${{ secrets.MARKUP_AI_API_KEY_PROD }}

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         # markupai/content-guardian-action (adds review-comment reconciliation:
         # stale comments are now auto-deleted on re-runs).
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@d0c776ff4c0948a02bb758fc7fc9a05319575ab9
+        uses: markupai/content-guardian-action@96a0b0fd32ba6529b5e5cef4299d9e8975781589
         with:
           target: Main
         env:

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         # markupai/content-guardian-action (adds review-comment reconciliation:
         # stale comments are now auto-deleted on re-runs).
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@7d7893dd9fe5fe0e9c261bde61c73b972da6be1a
+        uses: markupai/content-guardian-action@4289732252ef9146bdf34896f9cb484b1c5bc999
         with:
           target: Main
         env:

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         # markupai/content-guardian-action (adds review-comment reconciliation:
         # stale comments are now auto-deleted on re-runs).
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@7d7893d
+        uses: markupai/content-guardian-action@7d7893dd9fe5fe0e9c261bde61c73b972da6be1a
         with:
           target: Main
         env:

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -21,9 +21,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Markup AI Analysis
-        # v2 pre-release pinned to the commit on PR #335 in markupai/content-guardian-action.
+        # v2 pre-release pinned to the latest commit on PR #335 in
+        # markupai/content-guardian-action (adds review-comment reconciliation:
+        # stale comments are now auto-deleted on re-runs).
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@6e6ccc87bb5aa67657fa3663fe5d9637fe0ffbec
+        uses: markupai/content-guardian-action@7d7893d
         with:
           target: Main
         env:

--- a/markdown/sample-markdown-file-1.md
+++ b/markdown/sample-markdown-file-1.md
@@ -6,3 +6,5 @@ One of the biggest benefits of generative AI is its ability to **enhance creativ
 
 
 In the business world, generative AI is a game-changer for **productivity and efficiency**. It can automate repetitive tasks, such as generating reports, drafting emails, and summarizing long documents. This frees up employees to concentrate on more strategic and complex work. For instance, in marketing, AI can rapidly create personalized content for different audience segments, increasing engagement and conversion rates. In software development, it can assist with writing and debugging code, accelerating project timelines and reducing errors.
+
+This is a test commit

--- a/markdown/sample-markdown-file-2.md
+++ b/markdown/sample-markdown-file-2.md
@@ -6,6 +6,6 @@ For customer service, generative AI powers sophisticated chatbots and virtual as
 
 The ability of generative AI to analyze and synthesize vast amounts of data makes it a powerful asset for **data-driven decision-making**. It can identify trends, detect anomalies, and predict outcomes with remarkable precision. This is particularly valuable in financial services, where AI can be used for fraud detection and risk assessment. In retail, it can analyze purchasing patterns to offer highly personalized product recommendations, increasing sales and customer loyalty. Ultimately, generative AI helps businesses make more informed decisions, optimize their operations, and gain a competitive edge.
 
-## A new section for the v2 pilot
+## A New Section for the V2 Pilot
 
 This paragraph was added to exercise the v2 of the Markup AI Content Guardian action. The objective is to validate that risk-based scoring works end-to-end on a real PR; we will be checking how the inline review comments are placed and whether the summary table is rendered correctly.

--- a/markdown/sample-markdown-file-2.md
+++ b/markdown/sample-markdown-file-2.md
@@ -5,3 +5,7 @@ Generative AI is no longer a futuristic concept; it is a practical tool that is 
 For customer service, generative AI powers sophisticated chatbots and virtual assistants that can handle a high volume of customer inquiries with speed and accuracy. These AI agents can provide instant support, answer frequently asked questions, and even resolve complex issues, leading to higher customer satisfaction and lower operational costs. By automating these interactions, businesses can reallocate their human agents to handle more intricate customer problems that require empathy and a personal touch.
 
 The ability of generative AI to analyze and synthesize vast amounts of data makes it a powerful asset for **data-driven decision-making**. It can identify trends, detect anomalies, and predict outcomes with remarkable precision. This is particularly valuable in financial services, where AI can be used for fraud detection and risk assessment. In retail, it can analyze purchasing patterns to offer highly personalized product recommendations, increasing sales and customer loyalty. Ultimately, generative AI helps businesses make more informed decisions, optimize their operations, and gain a competitive edge.
+
+## A new section for the v2 pilot
+
+This paragraph was added to exercise the v2 of the Markup AI Content Guardian action. The objective is to validate that risk-based scoring works end-to-end on a real PR; we will be checking how the inline review comments are placed and whether the summary table is rendered correctly.


### PR DESCRIPTION
## Summary

Pilots [markupai/content-guardian-action#335](https://github.com/markupai/content-guardian-action/pull/335) in this test repo by pinning the workflow to that PR's commit (`6e6ccc8`).

Changes:

- `.github/workflows/markupai-analysis.yml` — pin action to commit `6e6ccc87bb5aa67657fa3663fe5d9637fe0ffbec`, swap `dialect`/`tone`/`style-guide` inputs for a single `target: Main`.
- `markdown/sample-markdown-file-2.md` — add a short paragraph so the `pull_request` event has changed supported content to analyze.

## What to validate

- CI runs the v2 action against this PR.
- The action posts a single summary PR comment with risk-based scoring (this org has `style_agent_numeric_scoring: false`).
- Inline review comments land on the new paragraph in `markdown/sample-markdown-file-2.md`.
- Commit status (from the `push` trigger) shows `Risk … | Files N | Issues …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)