### PR TITLE
demo: v2 PR-comment rendering (pinned to PR #335 commit c766459)

### DIFF
--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run Markup AI Analysis
         # v2 pre-release pinned to PR #335 in markupai/content-guardian-action.
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@113d61337a585b2e4eb590dffeb46710d7bafb15
+        uses: markupai/content-guardian-action@f44c6989a5761df8723c16751759afa3913cf677
         # No `target` input — the action falls back to the org's default
         # target (the one flagged `is_default: true`).
         env:

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run Markup AI Analysis
         # v2 pre-release pinned to PR #335 in markupai/content-guardian-action.
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@c766459b346d47b7fa70d641ec2d728e67e42e26
+        uses: markupai/content-guardian-action@113d61337a585b2e4eb590dffeb46710d7bafb15
         # No `target` input — the action falls back to the org's default
         # target (the one flagged `is_default: true`).
         env:

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run Markup AI Analysis
         # v2 pre-release pinned to PR #335 in markupai/content-guardian-action.
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@a898046b5fd4429cf3df509eb99cf4cfab63ed06
+        uses: markupai/content-guardian-action@65b7d095fbc319218d92048d100603107e94fc21
         # No `target` input — the action falls back to the org's default
         # target (the one flagged `is_default: true`).
         env:

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -4,13 +4,19 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: "0 8 * * *"
   workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: write
   statuses: write
+
+# Serialize CI runs per PR so two quick pushes don't race on the action's
+# review-comment reconciliation.
+concurrency:
+  group: markup-ai-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   content-quality-analysis:
@@ -21,12 +27,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Markup AI Analysis
-        uses: markupai/content-guardian-action@v1
-        with:
-          # valid tones: academic, confident, conversational, empathetic, engaging, friendly, professional, style_guide, technical
-          tone: professional
-          dialect: american_english
-          style-guide: microsoft
+        # v2 pre-release pinned to PR #335 in markupai/content-guardian-action.
+        # See https://github.com/markupai/content-guardian-action/pull/335
+        uses: markupai/content-guardian-action@c766459b346d47b7fa70d641ec2d728e67e42e26
+        # No `target` input — the action falls back to the org's default
+        # target (the one flagged `is_default: true`).
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MARKUP_AI_API_KEY: ${{ secrets.MARKUP_AI_API_KEY_PROD }}

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run Markup AI Analysis
         # v2 pre-release pinned to PR #335 in markupai/content-guardian-action.
         # See https://github.com/markupai/content-guardian-action/pull/335
-        uses: markupai/content-guardian-action@f44c6989a5761df8723c16751759afa3913cf677
+        uses: markupai/content-guardian-action@a898046b5fd4429cf3df509eb99cf4cfab63ed06
         # No `target` input — the action falls back to the org's default
         # target (the one flagged `is_default: true`).
         env:

--- a/markdown/demo-v2-features.md
+++ b/markdown/demo-v2-features.md
@@ -1,0 +1,13 @@
+# Demo: v2 PR-comment rendering
+
+This file was added to show off how the v2 action renders its PR summary and inline review comments. The point is to give the style agent something concrete to flag so that reviewers can see all four output surfaces at once.
+
+## Why this exists
+
+We will be checking how the inline review comments are placed, whether the summary table is rendered correctly, and that the new agent-attribution lines appear in both the inline-comment header and the footer of the summary comment.
+
+## What you should see
+
+- A single summary comment from the action with the risk table, the per-file breakdown, and the new "Detected by: Style Agent" line in the footer.
+- Inline review comments anchored to lines in this file, each headed with "Markup AI / Style Agent detected issues:" and listing the issues the agent picked up.
+- A clean PR — no stale comments from prior runs (the reconciler deletes outdated comments automatically).


### PR DESCRIPTION
## Why this PR exists

Clean stage for previewing the v2 action's PR-comment rendering. The polluted [test PR #26](https://github.com/markupai/github-action-testdata/pull/26) accumulated artifacts across many iterations; this one starts fresh against [markupai/content-guardian-action#335](https://github.com/markupai/content-guardian-action/pull/335) at commit \`c766459\`.

## What you should see once CI runs

- **One** summary comment from the action with the risk table, per-file breakdown, and a new \`Detected by: Style Agent\` footer line.
- **Inline review comments** anchored to lines in \`markdown/demo-v2-features.md\`, each headed with **\`Markup AI / Style Agent\` detected issues:** (the new agent attribution).
- A clean PR — no stale comments because there's no prior run history on this PR.

## What changed in the workflow

- Pinned to \`c766459\` (was \`@v1\`).
- Dropped the \`tone\` / \`dialect\` / \`style-guide\` inputs.
- No \`target\` set — the action falls back to the org's default target.
- Added a \`concurrency\` block so back-to-back pushes don't race on review-comment reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)