### PR TITLE
chore: upgrade to content-guardian-action v2

### DIFF
--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -21,12 +21,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Markup AI Analysis
-        uses: markupai/content-guardian-action@v1
+        uses: markupai/content-guardian-action@v2
         with:
-          # valid tones: academic, confident, conversational, empathetic, engaging, friendly, professional, style_guide, technical
-          tone: professional
-          dialect: american_english
-          style-guide: microsoft
+          # v2 replaces v1's dialect/tone/style-guide with a single optional
+          # `style_guide` — a style guide (target) ID or display name from your
+          # Markup AI org. Omit it to use the org's default style guide.
+          # Dialect and tone are now configured on the style guide at
+          # console.markup.ai rather than per-run here.
+          style_guide: Microsoft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MARKUP_AI_API_KEY: ${{ secrets.MARKUP_AI_API_KEY_PROD }}

--- a/.github/workflows/markupai-analysis.yml
+++ b/.github/workflows/markupai-analysis.yml
@@ -28,7 +28,7 @@ jobs:
           # Markup AI org. Omit it to use the org's default style guide.
           # Dialect and tone are now configured on the style guide at
           # console.markup.ai rather than per-run here.
-          style_guide: Microsoft
+          style_guide: Microsoft Manual of Style
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MARKUP_AI_API_KEY: ${{ secrets.MARKUP_AI_API_KEY_PROD }}

--- a/markdown/sample-markdown-file-1.md
+++ b/markdown/sample-markdown-file-1.md
@@ -6,3 +6,5 @@ One of the biggest benefits of generative AI is its ability to **enhance creativ
 
 
 In the business world, generative AI is a game-changer for **productivity and efficiency**. It can automate repetitive tasks, such as generating reports, drafting emails, and summarizing long documents. This frees up employees to concentrate on more strategic and complex work. For instance, in marketing, AI can rapidly create personalized content for different audience segments, increasing engagement and conversion rates. In software development, it can assist with writing and debugging code, accelerating project timelines and reducing errors.
+
+Looking ahead, lots of folks think this tech is gonna be utilized by basically every single company out there, and it's really, really going to change the game in a very big way for sure.


### PR DESCRIPTION
## Summary

Upgrades the analysis workflow in this test-data repo to **content-guardian-action `@v2`**, and makes a dummy markdown edit so the v2 run produces visible results on this PR.

### Workflow changes (`.github/workflows/markupai-analysis.yml`)
- `markupai/content-guardian-action@v1` → `@v2`.
- Replaced v1's `dialect` / `tone` / `style-guide: microsoft` with the single optional v2 input `style_guide: Microsoft`. Dialect and tone are now configured on the style guide at [console.markup.ai](https://console.markup.ai), not per-run.
- API key / GitHub token are unchanged — still passed via the existing `env` block (v2 reads `MARKUP_AI_API_KEY` / `GITHUB_TOKEN` env vars as fallbacks).

### Content change (`markdown/sample-markdown-file-1.md`)
- Added one paragraph with intentional style issues (informal "folks"/"gonna", redundancy, hedging) so the action surfaces findings — a PR summary comment plus inline review comments.

## What to verify on this PR
- The **Markup AI Content Analysis** check runs on `@v2`.
- A single summary PR comment appears, leading with a **risk label + severity counts** (numeric quality scores appear only if the org has numeric scoring enabled).
- Inline review comments land on the new paragraph's flagged lines.

## Note
`style_guide: Microsoft` assumes a style guide with that display name (or ID) exists in the org. If resolution fails, adjust the value to a valid display name/ID, or omit `style_guide` to fall back to the org's default style guide.